### PR TITLE
Replacing select and FD_SET with epoll to support more than 1024 fake switches

### DIFF
--- a/cbench/cbench.c
+++ b/cbench/cbench.c
@@ -10,6 +10,7 @@
 #include <string.h>
 #include <time.h>
 #include <unistd.h>
+#include <sys/epoll.h>
 
 #include <netinet/tcp.h>
 
@@ -26,6 +27,9 @@
 
 
 
+#define MAX_EVENTS	16
+struct epoll_event events[MAX_EVENTS];
+int epollfd;
 
 struct myargs my_options[] = {
     {"controller",  'c', "hostname of controller to connect to", MYARGS_STRING, {.string = "localhost"}},
@@ -44,6 +48,7 @@ struct myargs my_options[] = {
     {"connect-delay",  'i', "delay between groups of switches connecting to the controller (in ms)", MYARGS_INTEGER, {.integer = 0}},
     {"connect-group-size",  'I', "number of switches in a connection delay group", MYARGS_INTEGER, {.integer = 1}},
     {"learn-dst-macs",  'L', "send gratuitious ARP replies to learn destination macs before testing", MYARGS_FLAG, {.flag = 1}},
+    {"dpid-offset",  'o', "switch DPID offset", MYARGS_INTEGER, {.integer = 1}},
     {0, 0, 0, 0}
 };
 
@@ -69,17 +74,20 @@ double run_test(int n_fakeswitches, struct fakeswitch * fakeswitches, int mstest
         timersub(&now, &then, &diff);
         if( (1000* diff.tv_sec  + (float)diff.tv_usec/1000)> total_wait)
             break;
-        for(i = 0; i< n_fakeswitches; i++)
-            fakeswitch_set_pollfd(&fakeswitches[i], &pollfds[i]);
 
-        poll(pollfds, n_fakeswitches, 1000);      // block until something is ready or 100ms passes
+	for(i = 0; i < MAX_EVENTS; i++) {
+		events[i].events = EPOLLIN | EPOLLOUT;
+	}
+	
+	int nfds = epoll_wait(epollfd, events, MAX_EVENTS, -1);
 
-        for(i = 0; i< n_fakeswitches; i++)
-            fakeswitch_handle_io(&fakeswitches[i], &pollfds[i]);
+	for(i = 0; i < nfds; i++) {
+            fakeswitch_handle_io(events[i].data.ptr, events[i].events);
+	}
     }
     tNow = now.tv_sec;
     tmNow = localtime(&tNow);
-    printf("%02d:%02d:%02d.%03d %-3d switches: fmods/sec:  ", tmNow->tm_hour, tmNow->tm_min, tmNow->tm_sec, (int)(now.tv_usec/1000), n_fakeswitches);
+    printf("%02d:%02d:%02d.%03d %-3d switches: flows/sec:  ", tmNow->tm_hour, tmNow->tm_min, tmNow->tm_sec, (int)(now.tv_usec/1000), n_fakeswitches);
     usleep(100000); // sleep for 100 ms, to let packets queue
     for( i = 0 ; i < n_fakeswitches; i++)
     {
@@ -139,8 +147,15 @@ int timeout_connect(int fd, const char * hostname, int port, int mstimeout) {
 		freeaddrinfo(res);
 		return -1;
 	}
-	FD_ZERO(&fds);
-	FD_SET(fd, &fds);
+	
+    	struct epoll_event ev;
+    	int epollfd = epoll_create(1);
+	ev.events = EPOLLIN | EPOLLOUT | EPOLLERR;
+	ev.data.fd = fd;
+	if(epoll_ctl(epollfd, EPOLL_CTL_ADD, fd, &ev) == -1) {
+		printf("Cannot use epoll to create connection\n");
+		return -1;
+	}
 
 	if(mstimeout >= 0) 
 	{
@@ -158,18 +173,16 @@ int timeout_connect(int fd, const char * hostname, int port, int mstimeout) {
 				return -1;
 			}
 		}
-		ret = select(fd+1, NULL, &fds, NULL, &tv);
+		int nfds = epoll_wait(epollfd, &ev, 1, mstimeout);
 	}
 	freeaddrinfo(res);
-
-	if(ret != 1) 
-	{
-		if(ret == 0)
-			return -1;
-		else
-			return ret;
+	close(epollfd);
+	
+	if(ev.events & EPOLLERR) {
+		return -1;
+	} else {
+		return 0;
 	}
-	return 0;
 }
 
 /********************************************************************************/
@@ -254,6 +267,7 @@ int main(int argc, char * argv[])
     int     connect_delay = myargs_get_default_integer(my_options, "connect-delay");
     int     connect_group_size = myargs_get_default_integer(my_options, "connect-group-size");
     int     learn_dst_macs = myargs_get_default_flag(my_options, "learn-dst-macs");
+    int     dpid_offset = myargs_get_default_integer(my_options, "dpid-offset");
     int     mode = MODE_LATENCY;
     int     i,j;
 
@@ -321,6 +335,9 @@ int main(int argc, char * argv[])
             case 'I':
                 connect_group_size = atoi(optarg);
                 break;
+            case 'o':
+                dpid_offset = atoi(optarg);
+                break;
             default: 
                 myargs_usage(my_options, PROG_TITLE, "help message", NULL, 1);
         }
@@ -334,7 +351,7 @@ int main(int argc, char * argv[])
     fprintf(stderr, "cbench: controller benchmarking tool\n"
                 "   running in mode %s\n"
                 "   connecting to controller at %s:%d \n"
-                "   faking%s %d switches :: %d tests each; %d ms per test\n"
+                "   faking%s %d switches offset %d :: %d tests each; %d ms per test\n"
                 "   with %d unique source MACs per switch\n"
                 "   %s destination mac addresses before the test\n"
                 "   starting test with %d ms delay after features_reply\n"
@@ -346,6 +363,7 @@ int main(int argc, char * argv[])
                 controller_port,
                 should_test_range ? " from 1 to": "",
                 n_fakeswitches,
+                dpid_offset,
                 tests_per_loop,
                 mstestlen,
                 total_mac_addresses,
@@ -363,6 +381,13 @@ int main(int argc, char * argv[])
     double  max = 0.0;
     double  v;
     results = malloc(tests_per_loop * sizeof(double));
+
+    struct epoll_event ev;
+    epollfd = epoll_create(4096);
+    if(epollfd == -1) {
+    	fprintf(stderr, "Cannot create epollfd.\n");
+	exit(1);
+    }
 
     for( i = 0; i < n_fakeswitches; i++)
     {
@@ -382,10 +407,17 @@ int main(int argc, char * argv[])
         if(debug)
             fprintf(stderr,"Initializing switch %d ... ", i+1);
         fflush(stderr);
-        fakeswitch_init(&fakeswitches[i],sock,65536, debug, delay, mode, total_mac_addresses, learn_dst_macs);
+        fakeswitch_init(&fakeswitches[i],dpid_offset+i,sock,BUFLEN, debug, delay, mode, total_mac_addresses, learn_dst_macs);
         if(debug)
             fprintf(stderr," :: done.\n");
         fflush(stderr);
+	ev.events = EPOLLIN | EPOLLOUT;
+	ev.data.fd = sock;
+	ev.data.ptr = &fakeswitches[i];
+	if(epoll_ctl(epollfd, EPOLL_CTL_ADD, sock, &ev) == -1) {
+		fprintf(stderr, "Cannot add sock to epoll\n");
+		exit(1);
+	}
         if(count_bits(i+1) == 0)  // only test for 1,2,4,8,16 switches
             continue;
         if(!should_test_range && ((i+1) != n_fakeswitches)) // only if testing range or this is last

--- a/cbench/cbench.c
+++ b/cbench/cbench.c
@@ -18,14 +18,11 @@
 #include <sys/types.h>
 #include <sys/time.h>
 
-
 #include <openflow/openflow.h>
 
 #include "myargs.h"
 #include "cbench.h"
 #include "fakeswitch.h"
-
-
 
 #define MAX_EVENTS	16
 struct epoll_event events[MAX_EVENTS];
@@ -75,15 +72,16 @@ double run_test(int n_fakeswitches, struct fakeswitch * fakeswitches, int mstest
         if( (1000* diff.tv_sec  + (float)diff.tv_usec/1000)> total_wait)
             break;
 
-	for(i = 0; i < MAX_EVENTS; i++) {
-		events[i].events = EPOLLIN | EPOLLOUT;
-	}
-	
-	int nfds = epoll_wait(epollfd, events, MAX_EVENTS, -1);
+        for(i = 0; i < MAX_EVENTS; i++) {
+            events[i].events = EPOLLIN | EPOLLOUT;
+        }
+        
+        int nfds = epoll_wait(epollfd, events, MAX_EVENTS, -1);
 
-	for(i = 0; i < nfds; i++) {
+
+        for(i = 0; i < nfds; i++) {
             fakeswitch_handle_io(events[i].data.ptr, events[i].events);
-	}
+        }
     }
     tNow = now.tv_sec;
     tmNow = localtime(&tNow);
@@ -148,40 +146,40 @@ int timeout_connect(int fd, const char * hostname, int port, int mstimeout) {
 		return -1;
 	}
 	
-    	struct epoll_event ev;
-    	int epollfd = epoll_create(1);
-	ev.events = EPOLLIN | EPOLLOUT | EPOLLERR;
+    struct epoll_event ev;
+    int epollfd = epoll_create(1);
+    ev.events = EPOLLIN | EPOLLOUT | EPOLLERR;
 	ev.data.fd = fd;
 	if(epoll_ctl(epollfd, EPOLL_CTL_ADD, fd, &ev) == -1) {
-		printf("Cannot use epoll to create connection\n");
-		return -1;
+	    printf("Cannot use epoll to create connection\n");
+	    return -1;
 	}
 
 	if(mstimeout >= 0) 
 	{
-		tv.tv_sec = mstimeout / 1000;
-		tv.tv_usec = (mstimeout % 1000) * 1000;
+	    tv.tv_sec = mstimeout / 1000;
+	    tv.tv_usec = (mstimeout % 1000) * 1000;
 
-		errno = 0;
+	    errno = 0;
 
-		if(connect(fd, res->ai_addr, res->ai_addrlen) < 0) 
-		{
-			if((errno != EWOULDBLOCK) && (errno != EINPROGRESS))
-			{
-				fprintf(stderr, "timeout_connect: error connecting: %d\n", errno);
-				freeaddrinfo(res);
-				return -1;
-			}
-		}
-		int nfds = epoll_wait(epollfd, &ev, 1, mstimeout);
+	    if(connect(fd, res->ai_addr, res->ai_addrlen) < 0) 
+	    {
+		    if((errno != EWOULDBLOCK) && (errno != EINPROGRESS))
+		    {
+			    fprintf(stderr, "timeout_connect: error connecting: %d\n", errno);
+			    freeaddrinfo(res);
+			    return -1;
+		    }
+        }
+	    int nfds = epoll_wait(epollfd, &ev, 1, mstimeout);
 	}
-	freeaddrinfo(res);
-	close(epollfd);
+    freeaddrinfo(res);
+    close(epollfd);
 	
-	if(ev.events & EPOLLERR) {
-		return -1;
-	} else {
-		return 0;
+    if(ev.events & EPOLLERR) {
+	    return -1;
+    } else {
+	    return 0;
 	}
 }
 
@@ -411,13 +409,15 @@ int main(int argc, char * argv[])
         if(debug)
             fprintf(stderr," :: done.\n");
         fflush(stderr);
-	ev.events = EPOLLIN | EPOLLOUT;
-	ev.data.fd = sock;
-	ev.data.ptr = &fakeswitches[i];
-	if(epoll_ctl(epollfd, EPOLL_CTL_ADD, sock, &ev) == -1) {
-		fprintf(stderr, "Cannot add sock to epoll\n");
-		exit(1);
-	}
+	    ev.events = EPOLLIN | EPOLLOUT;
+	    ev.data.fd = sock;
+	    ev.data.ptr = &fakeswitches[i];
+
+	    if(epoll_ctl(epollfd, EPOLL_CTL_ADD, sock, &ev) == -1) {
+	    	fprintf(stderr, "Cannot add sock to epoll\n");
+	    	exit(1);
+    	}
+
         if(count_bits(i+1) == 0)  // only test for 1,2,4,8,16 switches
             continue;
         if(!should_test_range && ((i+1) != n_fakeswitches)) // only if testing range or this is last

--- a/cbench/cbench.c
+++ b/cbench/cbench.c
@@ -23,7 +23,7 @@
 #include "cbench.h"
 #include "fakeswitch.h"
 
-#ifdef linux
+#ifdef __linux__
 #include <sys/epoll.h>
 #define MAX_EVENTS	16
 struct epoll_event events[MAX_EVENTS];
@@ -74,7 +74,7 @@ double run_test(int n_fakeswitches, struct fakeswitch * fakeswitches, int mstest
         if( (1000* diff.tv_sec  + (float)diff.tv_usec/1000)> total_wait)
             break;
 
-        #ifdef linux
+        #ifdef __linux__
         for(i = 0; i < MAX_EVENTS; i++) {
             events[i].events = EPOLLIN | EPOLLOUT;
         }
@@ -83,7 +83,7 @@ double run_test(int n_fakeswitches, struct fakeswitch * fakeswitches, int mstest
 
 
         for(i = 0; i < nfds; i++) {
-            fakeswitch_handle_io(events[i].data.ptr, events[i].events);
+            fakeswitch_handle_io(events[i].data.ptr, &(events[i].events));
         }
         #else
         for(i = 0; i < n_fakeswitches; i++) 
@@ -158,7 +158,7 @@ int timeout_connect(int fd, const char * hostname, int port, int mstimeout) {
 		return -1;
 	}
 	
-    #ifdef linux
+    #ifdef __linux__
     struct epoll_event ev;
     int epollfd = epoll_create(1);
     ev.events = EPOLLIN | EPOLLOUT | EPOLLERR;
@@ -188,7 +188,7 @@ int timeout_connect(int fd, const char * hostname, int port, int mstimeout) {
 			    return -1;
 		    }
         }
-        #ifdef linux
+        #ifdef __linux__
 	    int nfds = epoll_wait(epollfd, &ev, 1, mstimeout);
         #else
         ret = select(fd + 1, NULL, &fds, NULL, &tv);
@@ -196,7 +196,7 @@ int timeout_connect(int fd, const char * hostname, int port, int mstimeout) {
 	}
     freeaddrinfo(res);
 
-    #ifdef linux
+    #ifdef __linux__
     close(epollfd);
 	
     if(ev.events & EPOLLERR) {
@@ -413,7 +413,7 @@ int main(int argc, char * argv[])
     double  v;
     results = malloc(tests_per_loop * sizeof(double));
 
-    #ifdef linux
+    #ifdef __linux__
     struct epoll_event ev;
     epollfd = epoll_create(4096);
     if(epollfd == -1) {
@@ -440,7 +440,7 @@ int main(int argc, char * argv[])
         if(debug)
             fprintf(stderr,"Initializing switch %d ... ", i+1);
         fflush(stderr);
-        #ifdef linux
+        #ifdef __linux__
         fakeswitch_init(&fakeswitches[i],dpid_offset+i,sock,BUFLEN, debug, delay, mode, total_mac_addresses, learn_dst_macs);
         #else
         fakeswitch_init(&fakeswitches[i], sock, 65536, debug, delay, mode, total_mac_addresses, learn_dst_macs);
@@ -450,7 +450,7 @@ int main(int argc, char * argv[])
             fprintf(stderr," :: done.\n");
         fflush(stderr);
     
-        #ifdef linux
+        #ifdef __linux__
 	    ev.events = EPOLLIN | EPOLLOUT;
 	    ev.data.fd = sock;
 	    ev.data.ptr = &fakeswitches[i];

--- a/cbench/cbench.h
+++ b/cbench/cbench.h
@@ -5,4 +5,8 @@
 #define BUFLEN 65536
 #endif
 
+#ifdef __linux__
+#define USE_EPOLL
+#endif
+
 #endif

--- a/cbench/fakeswitch.c
+++ b/cbench/fakeswitch.c
@@ -19,7 +19,7 @@
 #include "cbench.h"
 #include "fakeswitch.h"
 
-#ifdef __linux__
+#ifdef USE_EPOLL
 #include <sys/epoll.h>
 #endif
 
@@ -61,7 +61,7 @@ void fakeswitch_init(struct fakeswitch *fs, int dpid, int sock, int bufsize, int
     struct ofp_header ofph;
     fs->sock = sock;
     fs->debug = debug;
-    #ifdef __linux__
+    #ifdef USE_EPOLL
     fs->id = dpid;
     #else
     static int ID = 1;
@@ -527,7 +527,7 @@ static void fakeswitch_handle_write(struct fakeswitch *fs)
 /***********************************************************************/
 void fakeswitch_handle_io(struct fakeswitch *fs, void *pfd_events)
 {
-    #ifdef __linux__
+    #ifdef USE_EPOLL
     int events = *((int*) pfd_events);
     if(events & EPOLLIN) {
         fakeswitch_handle_read(fs);

--- a/cbench/fakeswitch.c
+++ b/cbench/fakeswitch.c
@@ -10,6 +10,7 @@
 #include <sys/socket.h>
 #include <sys/types.h>
 #include <sys/time.h>
+#include <sys/epoll.h>
 
 #include <net/ethernet.h>
 
@@ -51,14 +52,13 @@ static inline uint64_t ntohll(uint64_t n)
     return htonl(1) == 1 ? n : ((uint64_t) ntohl(n) << 32) | ntohl(n >> 32);
 }
 
-void fakeswitch_init(struct fakeswitch *fs, int sock, int bufsize, int debug, int delay, enum test_mode mode, int total_mac_addresses, int learn_dstmac)
+void fakeswitch_init(struct fakeswitch *fs, int dpid, int sock, int bufsize, int debug, int delay, enum test_mode mode, int total_mac_addresses, int learn_dstmac)
 {
-    static int ID =1 ;
     char buf[BUFLEN];
     struct ofp_header ofph;
     fs->sock = sock;
     fs->debug = debug;
-    fs->id = ID++;
+    fs->id = dpid;
     fs->inbuf = msgbuf_new(bufsize);
     fs->outbuf = msgbuf_new(bufsize);
     fs->probe_state = 0;
@@ -145,8 +145,6 @@ void fakeswitch_learn_dstmac(struct fakeswitch *fs)
 void fakeswitch_set_pollfd(struct fakeswitch *fs, struct pollfd *pfd)
 {
     pfd->events = POLLIN|POLLOUT;
-    /* if(msgbuf_count_buffered(fs->outbuf) > 0)
-        pfd->events |= POLLOUT; */
     pfd->fd = fs->sock;
 }
 
@@ -480,7 +478,7 @@ static void fakeswitch_handle_write(struct fakeswitch *fs)
     char buf[BUFLEN];
     int count ;
     int send_count = 0 ;
-    int throughput_buffer = 65536;
+    int throughput_buffer = BUFLEN;
     int i;
     if( fs->switch_status == READY_TO_SEND) 
     {
@@ -521,12 +519,13 @@ static void fakeswitch_handle_write(struct fakeswitch *fs)
         msgbuf_write(fs->outbuf, fs->sock, 0);
 }
 /***********************************************************************/
-void fakeswitch_handle_io(struct fakeswitch *fs, const struct pollfd *pfd)
+void fakeswitch_handle_io(struct fakeswitch *fs, int events)
 {
-    if(pfd->revents & POLLIN)
+    if(events & EPOLLIN) {
         fakeswitch_handle_read(fs);
-    if(pfd->revents & POLLOUT)
+    } else if(events & EPOLLOUT) {
         fakeswitch_handle_write(fs);
+    }
 }
 /************************************************************************/
 static int debug_msg(struct fakeswitch * fs, char * msg, ...)
@@ -539,6 +538,5 @@ static int debug_msg(struct fakeswitch * fs, char * msg, ...)
     vfprintf(stderr,msg,aq);
     if(msg[strlen(msg)-1] != '\n')
         fprintf(stderr, "\n");
-    // fflush(stderr);     // should be redundant, but often isn't :-(
     return 1;
 }

--- a/cbench/fakeswitch.h
+++ b/cbench/fakeswitch.h
@@ -53,8 +53,11 @@ struct fakeswitch
  * @param total_mac_addresses      The total number of unique mac addresses
  *                                 to use for packet ins from this switch
  */
+#ifdef linux
 void fakeswitch_init(struct fakeswitch *fs, int dpid, int sock, int bufsize, int debug, int delay, enum test_mode mode, int total_mac_addresses, int learn_dstmac);
-
+#else
+void fakeswitch_init(struct fakeswitch *fs, int sock, int bufsize, int debug, int delay, enum test_mode mode, int total_mac_addresses, int learn_dstmac);
+#endif
 
 /*** Set the desired flags for poll()
  * @param fs    Pointer to initalized fakeswitch
@@ -72,8 +75,11 @@ void fakeswitch_set_pollfd(struct fakeswitch *fs, struct pollfd *pfd);
  * @param fs    Pointer to initalized fakeswitch
  * @param pfd   Pointer to an allocated poll structure
  */
+#ifdef linux
 void fakeswitch_handle_io(struct fakeswitch *fs, int events);
-
+#else
+void fakeswitch_handle_io(struct fakeswitch *fs, const struct pollfd *pfd);
+#endif
 /**** Get and reset count 
  * @param fs    Pointer to initialized fakeswitch
  * @return      Number of flow_mod responses since last call

--- a/cbench/fakeswitch.h
+++ b/cbench/fakeswitch.h
@@ -53,11 +53,7 @@ struct fakeswitch
  * @param total_mac_addresses      The total number of unique mac addresses
  *                                 to use for packet ins from this switch
  */
-#ifdef linux
 void fakeswitch_init(struct fakeswitch *fs, int dpid, int sock, int bufsize, int debug, int delay, enum test_mode mode, int total_mac_addresses, int learn_dstmac);
-#else
-void fakeswitch_init(struct fakeswitch *fs, int sock, int bufsize, int debug, int delay, enum test_mode mode, int total_mac_addresses, int learn_dstmac);
-#endif
 
 /*** Set the desired flags for poll()
  * @param fs    Pointer to initalized fakeswitch
@@ -73,13 +69,9 @@ void fakeswitch_set_pollfd(struct fakeswitch *fs, struct pollfd *pfd);
  *      if it's a flow_mod, then incremenet count
  *      else ignore it
  * @param fs    Pointer to initalized fakeswitch
- * @param pfd   Pointer to an allocated poll structure
+ * @param pfd   Pointer to an allocated poll structure or the number of events as int
  */
-#ifdef linux
-void fakeswitch_handle_io(struct fakeswitch *fs, int events);
-#else
-void fakeswitch_handle_io(struct fakeswitch *fs, const struct pollfd *pfd);
-#endif
+void fakeswitch_handle_io(struct fakeswitch *fs, void* pfd_events);
 /**** Get and reset count 
  * @param fs    Pointer to initialized fakeswitch
  * @return      Number of flow_mod responses since last call

--- a/cbench/fakeswitch.h
+++ b/cbench/fakeswitch.h
@@ -53,7 +53,7 @@ struct fakeswitch
  * @param total_mac_addresses      The total number of unique mac addresses
  *                                 to use for packet ins from this switch
  */
-void fakeswitch_init(struct fakeswitch *fs, int sock, int bufsize, int debug, int delay, enum test_mode mode, int total_mac_addresses, int learn_dstmac);
+void fakeswitch_init(struct fakeswitch *fs, int dpid, int sock, int bufsize, int debug, int delay, enum test_mode mode, int total_mac_addresses, int learn_dstmac);
 
 
 /*** Set the desired flags for poll()
@@ -72,7 +72,7 @@ void fakeswitch_set_pollfd(struct fakeswitch *fs, struct pollfd *pfd);
  * @param fs    Pointer to initalized fakeswitch
  * @param pfd   Pointer to an allocated poll structure
  */
-void fakeswitch_handle_io(struct fakeswitch *fs, const struct pollfd *pfd);
+void fakeswitch_handle_io(struct fakeswitch *fs, int events);
 
 /**** Get and reset count 
  * @param fs    Pointer to initialized fakeswitch


### PR DESCRIPTION
I replaced select and FD_SET functions in cbench.c to epoll to support more than 1024 fake switches.
I have tested it with 2048 switches and it works well.
Before run it, you need to set open files limits to more than 1024 using "ulimit -n 4096."
I set the __FD_SETSIZE to 4096 at /usr/include/bits/typesizes.h.
In case you need more than 4096 open connections, you can set the limits with a higher value.
I guess that depends on systems.
